### PR TITLE
docs: CLAUDE.md에 PR 작성 가이드(한국어) 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,7 @@ Required in `.env`: `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_PROJE
 - Tailwind uses a custom color palette defined in `index.html` `<script>` block: `deep`, `base`, `card`, `accent` (red), `blu`, `grn`, `org`, `yel`, `gry`, `txt-primary`/`secondary`/`tertiary`
 - Frontend uses IIFE pattern for module encapsulation, var declarations (no let/const), no module bundler
 - TypeScript is lenient: `strictNullChecks: false`, `noImplicitAny: false`
+
+## PR 작성 가이드
+
+- PR 설명(본문)은 한국어로 작성합니다.


### PR DESCRIPTION
### Motivation

- 리포지토리 전반에서 PR 본문을 한국어로 작성하도록 명시해 일관된 문서화 규칙을 제공하기 위해서입니다.

### Description

- `CLAUDE.md`에 `## PR 작성 가이드` 섹션을 추가하고 내부에 `PR 설명(본문)은 한국어로 작성합니다.` 규칙을 명시했습니다.

### Testing

- `npm run build`를 실행하여 빌드가 정상적으로 완료되는 것을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1c45aa3c8325836ff34df7a81583)